### PR TITLE
Created 0.4.0 - AbstractLoggable in JLogEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ logger.info(`Process started at port $PORT`);
 logger.error('Failed to processing incoming request', err);
 ```
 
-### Install
+### Install
 
 ```
 npm i jlog-facade

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jlog-facade",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Logger façade that focusing on creating a JSON output for typescript projects",
     "main": "lib/index.js",
     "repository": "https://github.com/fp8/jlog-facade.git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -115,7 +115,7 @@ export function convertValueToIJson(input: TLoggableValue | TLoggableValue[]): T
     } else {
         return convertValueToJsonValue(input);
     }
-} 
+}
 
 /**
  * Method used to merge 2 IJson object, from `input` into `cummulator`.

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,6 @@
+// ROOT LEVEL PACKAGE -- Allowed to import only from STAND-ALONE packages from this project
+import {isArray} from './helper';
+
 /**
  * Allowed Json Value Type
  */
@@ -9,6 +12,11 @@ export type TJsonValue = string | number | boolean | IJson | null | undefined;
 export interface IJson {
     [key: string]: TJsonValue | TJsonValue[]
 }
+
+/**
+ * Type of value that can be written to logger
+ */
+export type TLoggableValue = TJsonValue | AbstractLoggable;
 
 /**
  * Supported log severity.
@@ -48,8 +56,12 @@ export interface IJLogEntry {
     message: string,
     /** error object */
     error?: Error,
+    /** all AbstractLoggables */
+    loggables?: AbstractLoggable[],
     /** additional attributes to log */
     data?: IJson,
+    /** any value logged */
+    values?: TJsonValue[],
     /** timestamp of the log */
     time: Date
 }
@@ -73,4 +85,49 @@ export abstract class AbstractLogDestination {
  */
 export abstract class AbstractAsyncLogDestination {
     abstract write(entry: IJLogEntry): Promise<void>;
+}
+
+/**
+ * Transform a loggable value into a TJsonValue
+ *
+ * @param input 
+ * @returns 
+ */
+function convertValueToJsonValue(input: TLoggableValue): TJsonValue {
+    if (input instanceof AbstractLoggable) {
+        return input.toIJson();
+    } else {
+        return input;
+    }
+}
+
+/**
+ * Transform a loggable value into a TJsonValue, handling case where input is an array
+ *
+ * @param input 
+ * @returns 
+ */
+export function convertValueToIJson(input: TLoggableValue | TLoggableValue[]): TJsonValue | TJsonValue[] {
+    if (isArray(input)) {
+        return input.map(
+            entry => convertValueToJsonValue(entry)
+        )
+    } else {
+        return convertValueToJsonValue(input);
+    }
+} 
+
+/**
+ * Method used to merge 2 IJson object, from `input` into `cummulator`.
+ *
+ * @param input source IJson
+ * @param cummulator destination IJson
+ */
+export function mergeIJson(cummulator: IJson, ...values: IJson[]) {
+    // Merge incoming IJson into data
+    for (const entry of values) {
+        for (const [key, value] of Object.entries(entry)) {
+            cummulator[key] = value;
+        }
+    }
 }

--- a/src/dest.ts
+++ b/src/dest.ts
@@ -1,4 +1,5 @@
-import { AbstractLogDestination, IJLogEntry, IJson } from "./core";
+import { AbstractLogDestination, AbstractLoggable, IJLogEntry, IJson, mergeIJson, TJsonValue } from "./core";
+import { mergeLoggableModels } from './models';
 import { isEmpty } from "./helper";
 
 export interface ISimpleJsonOutput extends IJson {
@@ -6,6 +7,38 @@ export interface ISimpleJsonOutput extends IJson {
     m: string; // 1 char severity + message
     e?: string; // error message
 }
+
+export function buildOutputDataForDestination(loggables?: AbstractLoggable[], data?: IJson, values?: TJsonValue[]): IJson {
+    let output: IJson;
+    if (data === undefined) {
+        output = {};
+    } else {
+        output = Object.assign({}, data);
+    }
+
+    // Check if value exists
+    const outputValues: TJsonValue[] = [];
+    if (values !== undefined) {
+        outputValues.push(...values);
+    }
+
+    // Process loggables
+    if (loggables !== undefined) {
+        const {loggableJson, loggableValues} = mergeLoggableModels(...loggables);
+        mergeIJson(output, loggableJson);
+        if (!isEmpty(loggableValues)) {
+            outputValues.push(...loggableValues);
+        }
+    }
+
+    // Add values to the output
+    if (!isEmpty(outputValues)) {
+        output.values = outputValues;
+    }
+
+    return output;
+}
+
 
 /**
  * A minimalistic json based destination that will output json in the following sequence:
@@ -22,8 +55,7 @@ export class SimpleJsonDestination extends AbstractLogDestination {
     }
 
     protected formatOutput(entry: IJLogEntry): ISimpleJsonOutput {
-        // Create a clone of data
-        const data: IJson = Object.assign({}, entry.data);
+        const data = buildOutputDataForDestination(entry.loggables, entry.data, entry.values);
 
         let stack: string | undefined = undefined;
         if (this.logStackTrace && entry.error) {
@@ -67,9 +99,10 @@ export class SimpleTextDestination extends AbstractLogDestination {
         }
 
         // Create a clone of data
+        const merged = buildOutputDataForDestination(entry.loggables, entry.data, entry.values);
         let data = '';
-        if (!isEmpty(entry.data)) {
-            data = ` ${JSON.stringify(entry.data)}`;
+        if (!isEmpty(merged)) {
+            data = ` ${JSON.stringify(merged)}`;
         }
 
         return `${header} ${entry.message}${error}${data}`;

--- a/src/dest.ts
+++ b/src/dest.ts
@@ -8,6 +8,16 @@ export interface ISimpleJsonOutput extends IJson {
     e?: string; // error message
 }
 
+/**
+ * Merge extra attributes from JLogEntry (loggables, data and values) into a single Json.  In this case,
+ * the keys in loggables takes priority over those in data; ie, the key in loggable will always overwrite
+ * those in data.
+ * 
+ * @param loggables 
+ * @param data 
+ * @param values 
+ * @returns 
+ */
 export function buildOutputDataForDestination(loggables?: AbstractLoggable[], data?: IJson, values?: TJsonValue[]): IJson {
     let output: IJson;
     if (data === undefined) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,3 +1,5 @@
+// STAND-ALONE PACKAGE -- Must not import anything from this project
+
 /**
  * A simple delay function 
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export class LoggerFactory {
 }
 
 export {
-    TJsonValue, IJson, IJLogEntry,
+    TJsonValue, TLoggableValue, IJson, IJLogEntry,
     LogSeverity, LogLevel,
     AbstractLoggable,
     AbstractLogDestination, AbstractAsyncLogDestination

--- a/src/models.ts
+++ b/src/models.ts
@@ -17,7 +17,7 @@ function appendToSet<T>(cummulator: Set<T>, input: T | T[]): void {
 /**
  * Merge a list of KVs into a IJson, optionally merging the values into an array of values.
  * 
- * If mergeValue is FALSE, the first key in the list prevail
+ * If mergeValue is FALSE, the last key in the list prevail
  *
  * @param mergeValue 
  * @param kvs 

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,7 +4,7 @@ import {
     convertValueToIJson, mergeIJson
 } from "./core";
 
-import {isEmpty, isObject} from './helper';
+import {isObject} from './helper';
 
 
 /**
@@ -21,6 +21,8 @@ function mergeKV(mergeValue: boolean, kvs: KV<TLoggableValue>[]): IJson {
     const merged: { [key: string]: Set<TJsonValue | TJsonValue[]>} = {};
 
     // Ensure that no dup key exists
+    // NB.: as the input comes from result of JLogger.extractData, the entries in the list are already
+    // in the reverse order from the caller's perspective.  Must not reverse the order of kvs again here.
     for (const kv of kvs) {
         const key = kv.key;
         const value = kv.value;

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,60 +1,174 @@
 import {
     TJsonValue, IJson,
-    AbstractLoggable
+    AbstractLoggable, TLoggableValue,
+    convertValueToIJson, mergeIJson
 } from "./core";
 
-export type TLoggableType = TJsonValue | AbstractLoggable;
+import {isEmpty, isObject} from './helper';
+
+
+/**
+ * Merge a list of KVs into a IJson, optionally merging the values into an array of values.
+ * 
+ * If mergeValue is FALSE, the first key in the list prevail
+ *
+ * @param mergeValue 
+ * @param kvs 
+ * @returns 
+ */
+function mergeKV(mergeValue: boolean, kvs: KV<TLoggableValue>[]): IJson {
+    const result: { [key: string]: TJsonValue | TJsonValue[]} = {};
+    const merged: { [key: string]: Set<TJsonValue | TJsonValue[]>} = {};
+
+    // Ensure that no dup key exists
+    for (const kv of kvs) {
+        const key = kv.key;
+        const value = kv.value;
+
+        /*
+        Merge the value to a Set if mergeValue flag is set.  If flag is set to false,
+        the repeated key instance is ignored.
+        */
+        if (mergeValue === true && key in result) {
+            if (key in merged) {
+                // Already exists in merged, just add to Set
+                merged[key].add(
+                    convertValueToIJson(value)
+                );
+            } else {
+                // First time
+                merged[key] = new Set<TJsonValue | TJsonValue[]>([
+                    convertValueToIJson(value)
+                ]);
+            }
+        } else {
+            result[key] = convertValueToIJson(value);
+        }
+    }
+
+    // If merged exists, replace result's key with list from merged
+    if (Object.keys(merged).length) {
+        for (const [key, value] of Object.entries(merged)) {
+            result[key] = Array.from(value.values()) as TJsonValue | TJsonValue[];
+        }
+    }
+
+    return result;
+}
+
+
+/**
+ * Merge a list of AbstractLogger into a single IJson.  This method will first break-down the input
+ * into 3 different lists:
+ * 
+ * 1. Create a list of KV from the input of loggables
+ * 1. Create a list of IJson from remaining input of loggables
+ * 1. Create a list of values where loggables are not an object
+ * 
+ * It then perform merging by using following steps (note that later entry overwrtes previous ones):
+ * 
+ * 1. Merge list of IJson to output
+ * 1. Merge first the list of KV using mergeKV and then merge the result into output
+ * 1. Return data as IJson and values as list of TJsonValue
+ * 
+ * **Note:** The values is expected to already return empty as those should have been
+ * filtered out by `JLogger.extractData` method.
+ * 
+ * @param loggables 
+ * @returns 
+ */
+export function mergeLoggableModels<T extends TLoggableValue>(...loggables: AbstractLoggable[]): {
+    loggableJson: IJson,
+    loggableValues: TJsonValue[]
+} {
+    const json: IJson[] = [];
+    const kvs: KV<T>[] = [];
+    const loggableValues: TJsonValue[] = [];
+
+    // Break the input list into different type of container
+    for (const loggable of loggables) {
+        if (loggable instanceof KV) {
+            kvs.push(loggable);
+        } else if (loggable instanceof AbstractLoggable) {
+            json.push(loggable.toIJson())
+        } else if (isObject(loggable)) {
+            json.push(loggable)
+        } else {
+            loggableValues.push(loggable);
+        }
+    }
+
+    // Build output data
+    const loggableJson: IJson = {};
+
+    const kvJson = mergeKV(false, kvs);
+    mergeIJson(loggableJson, ...json, kvJson);
+
+    return {loggableJson, loggableValues};
+}
 
 /**
  * Allow adding of a simple key/value pair to a log.  When multiple
  * key is detected, the first key logged prevails over subsequent
  * value assigned to the same key
  */
-export class KV<T extends TLoggableType> extends AbstractLoggable {
-    constructor(public readonly key: string, private value: T) {
+export class KV<T extends TLoggableValue> extends AbstractLoggable {
+    /**
+     * Merge list of KVs and skip duplicate key if found later in the list
+     *
+     * @param kvs 
+     * @returns 
+     */
+    public static merge<T extends TLoggableValue>(...kvs: KV<T>[]): IJson {
+        return mergeKV(false, kvs)
+    }
+
+    /**
+     * Merge list of KVs if duplicate keys found, convert the value into an array.
+     * 
+     * **N.B.:** Use this method with caution as downstream system such as logstash
+     * does not like when datatype of a key changes.  It could result in the log
+     * being missed.
+     * 
+     * @param kvs 
+     * @returns 
+     */
+    public static mergeValue<T extends TLoggableValue>(...kvs: KV<T>[]): IJson {
+        return mergeKV(false, kvs)
+    }
+
+    constructor(public readonly key: string, public readonly value: T | T[]) {
         super();
     }
 
+    /**
+     * Convert KV into a JSON
+     *
+     * @returns 
+     */
     toIJson(): IJson {
-        const result: IJson = {};
-        const value = this.value;
-        if (value instanceof AbstractLoggable) {
-            result[this.key] = value.toIJson();
-        } else {
-            result[this.key] = value;
-        }
-        
-        return result;
+        return {
+            [this.key]: convertValueToIJson(this.value)
+        };
     }
 }
+
+/**
+ * A single key value pair where value is always string
+ */
+export class Label extends KV<string> {}
 
 /**
  * Allow adding of a key/value pair to a log where resulting value
  * is always a list.  When multiple key is detected, the values
  * are merged.
  */
- export class Label<T extends TLoggableType> extends AbstractLoggable {
-    private _values: TLoggableType[];
+ export class Tags<T extends TLoggableValue> extends KV<T> {
+    override value: T[];
 
-    constructor(public readonly key: string, ...values: T[]) {
-        super();
-        this._values = values;
-    }
-
-    public get values(): TJsonValue[] {
-        return this._values.map(entry => {
-            if (entry instanceof AbstractLoggable) {
-                return entry.toIJson();
-            } else {
-                return entry;
-            }
-        });
-    }
-
-    toIJson(): IJson {
-        const result: IJson = {};
-        result[this.key] = this.values;
-        return result;
+    constructor(key: string, ...values: T[]) {
+        super(key, values);
+        this.value = values;
     }
 }
 

--- a/test/dest.spec.ts
+++ b/test/dest.spec.ts
@@ -34,7 +34,7 @@ class TestSimpleJsonDestination extends SimpleJsonDestination {
 
 
 
-describe.only('dest', () => {
+describe('dest', () => {
     const logger = LoggerFactory.create('my-logger');
 
     beforeEach(() => {
@@ -80,14 +80,14 @@ describe.only('dest', () => {
         expect(logCollector).is.eql(['{"m":"I|Info message for UurqWHYMyJ","processId":"UurqWHYMyJ"}']);
     });
 
-    it.only('json - error', () => {
+    it('json - error', () => {
         LoggerFactory.addLogDestination(new TestSimpleJsonDestination(false));
         const error = new Error('vOGQbtxvfD');
         logger.error(error);
         expect(logCollector).is.eql(['{"m":"E|vOGQbtxvfD","e":"Error: vOGQbtxvfD"}']);
     });
 
-    it.only('json - error with stack', () => {
+    it('json - error with stack', () => {
         LoggerFactory.addLogDestination(new TestSimpleJsonDestination());
         const error = new Error('qbsKviHUSV');
         logger.warn('qbsKviHUSV did not work', error);

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from './testlib';
 
-import {IJson, KV, Label} from '@fp8proj';
+import {IJson, KV, Tags} from '@fp8proj';
 
 class KVS extends KV<string> {}
 
-class KVLabel extends KV<Label<string>> {}
+class KVLabel extends KV<Tags<number>> {}
 
-class StringLabel extends Label<string> {}
+class StringLabel extends Tags<string> {}
 
 
 describe('models', () => {
@@ -16,7 +16,7 @@ describe('models', () => {
     });
 
     it('simple KVLabel', () => {
-        const entry = new KVLabel('testKVLabel', new Label('testLabel', 8090, 6860));
+        const entry = new KVLabel('testKVLabel', new Tags('testLabel', 8090, 6860));
         expect(entry.toIJson()).to.eql({ testKVLabel: {testLabel: [8090, 6860]} });
     });
 

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -1,8 +1,10 @@
 import {expect} from './testlib';
 
-import {IJson, KV, Tags} from '@fp8proj';
+import {KV, Label, Tags} from '@fp8proj';
 
 class KVS extends KV<string> {}
+
+class SimpleTags extends Tags<string> {}
 
 class KVLabel extends KV<Tags<number>> {}
 
@@ -15,6 +17,19 @@ describe('models', () => {
         expect(entry.toIJson()).to.eql({ testKVS: 'pvyvhZyS63' })
     });
 
+    it('simple Label', () => {
+        const entry = new Label('testLabel', 'bKutvGvLoa');
+        expect(entry.toIJson()).to.eql({testLabel: 'bKutvGvLoa'})
+    });
+
+    it('SimpleTags', () => {
+        const entry = new SimpleTags('testTags', '80qes03Ftr');
+        expect(entry.toIJson()).to.eql({testTags: ['80qes03Ftr']})
+
+        const entry2 = new SimpleTags('testTags2', 'WL5oW2Vhll', 'WL5oW2Vhll');
+        expect(entry2.toIJson()).to.eql({testTags2: ['WL5oW2Vhll', 'WL5oW2Vhll']})
+    });
+
     it('simple KVLabel', () => {
         const entry = new KVLabel('testKVLabel', new Tags('testLabel', 8090, 6860));
         expect(entry.toIJson()).to.eql({ testKVLabel: {testLabel: [8090, 6860]} });
@@ -23,6 +38,49 @@ describe('models', () => {
     it('simple StringLabel', () => {
         const entry = new StringLabel('testStringLabel', 'dDVfo39D3f', 'HCJejdQNBT');
         expect(entry.toIJson()).to.eql({ testStringLabel: ['dDVfo39D3f', 'HCJejdQNBT'] });
+    });
+
+    it('merge kvs simple', () => {
+        const kvs = [
+            new KVS('testKVS', 'UyjlxKJXUN'),
+            new Label('testLabel', 'JuSyAWXhZ7'),
+            new SimpleTags('testTags', 'XKx4IHlWmH')
+        ];
+
+        const merged = KV.merge(...kvs);
+        expect(merged).is.eql({
+            testKVS: 'UyjlxKJXUN',
+            testLabel: 'JuSyAWXhZ7',
+            testTags: [ 'XKx4IHlWmH' ]
+        });
+    });
+
+    it('merge kvs merge key', () => {
+        const kvs = [
+            new KVS('key1', 'Ex8roHjRct'),
+            new Label('key2', 'hu60CM6WgB'),
+            new SimpleTags('key1', '5WGjFwxdCZ')
+        ];
+
+        const merged = KV.merge(...kvs);
+        expect(merged).is.eql({
+            key1: [ '5WGjFwxdCZ' ],
+            key2: 'hu60CM6WgB',
+        });
+    });
+
+    it('merge kvs merge value', () => {
+        const kvs = [
+            new KVS('key1', '0iu7dUwEE6'),
+            new Label('key2', 'xV49Qdk17g'),
+            new SimpleTags('key1', 'WDlBAwENwK')
+        ];
+
+        const merged = KV.mergeValue(...kvs);
+        expect(merged).is.eql({
+            key1: [ '0iu7dUwEE6', 'WDlBAwENwK' ],
+            key2: 'xV49Qdk17g',
+        });
     });
 
 });


### PR DESCRIPTION
* loggables added to JLogEntry allowing destination to customize the output
* values added to JLogEntry to capture any non-object entries logged
* Label is now a simple KV<string> and accept only one values
* Tags created to support multiple values per key
* KV.merge and KV.mergeValue added as helper to merge instances of KV into IJson
* buildOutputDataForDestination function added to create a single Json from loggables, Json and values into a single Json.  Essentially exposing the previous JLogger.data behaviour.
