### PR TITLE
Create v0.5.0 with License File and Bug Fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Farport Software S.r.l.
+Copyright (c) 2023 Farport Software S.r.l.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Farport Software S.r.l.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jlog-facade",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Logger façade that focusing on creating a JSON output for typescript projects",
     "main": "lib/index.js",
     "repository": "https://github.com/fp8/jlog-facade.git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,16 @@ export class LoggerFactory {
     }
 
     /**
+     * Create a synonymous for .create
+     *
+     * @param name 
+     * @returns 
+     */
+    public static getLogger(name: string): JLogger {
+        return LoggerFactory.create(name);
+    }
+
+    /**
      * Add a destination to output the log
      *
      * @param destination 

--- a/src/models.ts
+++ b/src/models.ts
@@ -124,6 +124,20 @@ export function mergeLoggableModels<T extends TLoggableValue>(...loggables: Abst
  * value assigned to the same key
  */
 export class KV<T extends TLoggableValue> extends AbstractLoggable {
+    protected _key: string;
+    protected _value: T | T[];
+
+    /**
+     * Factory method for KV
+     *
+     * @param key 
+     * @param value 
+     * @returns 
+     */
+    public static of<T extends TLoggableValue>(key: string, value: T): KV<T> {
+        return new KV(key, value);
+    }
+
     /**
      * Merge list of KVs and skip duplicate key if found later in the list
      *
@@ -148,8 +162,18 @@ export class KV<T extends TLoggableValue> extends AbstractLoggable {
         return mergeKV(true, kvs)
     }
 
-    constructor(public readonly key: string, public readonly value: T | T[]) {
+    constructor(key: string, value: T) {
         super();
+        this._key = key;
+        this._value = value;
+    }
+
+    public get key(): string {
+        return this._key;
+    }
+
+    public get value(): T | T[] {
+        return this._value;
     }
 
     /**
@@ -162,12 +186,25 @@ export class KV<T extends TLoggableValue> extends AbstractLoggable {
             [this.key]: convertValueToIJson(this.value)
         };
     }
+
+
 }
 
 /**
  * A single key value pair where value is always string
  */
-export class Label extends KV<string> {}
+export class Label extends KV<string> {
+    override _value: string;
+
+    override get value(): string {
+        return this._value;
+    }
+
+    constructor(key: string, value: string) {
+        super(key, value);
+        this._value = value;
+    }
+}
 
 /**
  * Allow adding of a key/value pair to a log where resulting value
@@ -175,11 +212,26 @@ export class Label extends KV<string> {}
  * are merged.
  */
  export class Tags<T extends TLoggableValue> extends KV<T> {
-    override value: T[];
+    override _value: T[];
+
+    /**
+     * Factory method for KV
+     *
+     * @param key 
+     * @param value 
+     * @returns 
+     */
+    static override of<T extends TLoggableValue>(key: string, ...values: T[]): Tags<T> {
+        return new Tags(key, ...values);
+    }
+
+    override get value(): T[] {
+        return this._value;
+    }
 
     constructor(key: string, ...values: T[]) {
-        super(key, values);
-        this.value = values;
+        super(key, '');
+        this._value = values;
     }
 }
 

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -18,7 +18,7 @@ describe('models', () => {
     });
 
     it('simple Label', () => {
-        const entry = new Label('testLabel', 'bKutvGvLoa');
+        const entry = Label.of('testLabel', 'bKutvGvLoa');
         expect(entry.toIJson()).to.eql({testLabel: 'bKutvGvLoa'})
     });
 
@@ -26,12 +26,12 @@ describe('models', () => {
         const entry = new SimpleTags('testTags', '80qes03Ftr');
         expect(entry.toIJson()).to.eql({testTags: ['80qes03Ftr']})
 
-        const entry2 = new SimpleTags('testTags2', 'WL5oW2Vhll', 'WL5oW2Vhll');
+        const entry2 = SimpleTags.of('testTags2', 'WL5oW2Vhll', 'WL5oW2Vhll');
         expect(entry2.toIJson()).to.eql({testTags2: ['WL5oW2Vhll', 'WL5oW2Vhll']})
     });
 
     it('simple KVLabel', () => {
-        const entry = new KVLabel('testKVLabel', new Tags('testLabel', 8090, 6860));
+        const entry = new KVLabel('testKVLabel', Tags.of('testLabel', 8090, 6860));
         expect(entry.toIJson()).to.eql({ testKVLabel: {testLabel: [8090, 6860]} });
     });
 
@@ -71,9 +71,9 @@ describe('models', () => {
 
     it('merge kvs merge value', () => {
         const kvs = [
-            new KVS('key1', '0iu7dUwEE6'),
-            new Label('key2', 'xV49Qdk17g'),
-            new SimpleTags('key1', 'WDlBAwENwK')
+            KVS.of('key1', '0iu7dUwEE6'),
+            Label.of('key2', 'xV49Qdk17g'),
+            SimpleTags.of('key1', 'WDlBAwENwK')
         ];
 
         const merged = KV.mergeValue(...kvs);


### PR DESCRIPTION
* Added MIT license file
* Added `LoggerFactory.getLogger` method for backward compatibility
* Cleaned up the data type for `KV` and added `.of` static method
