### PR TITLE
feat(jlogger): exposed name property in JLogger

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # jlog-facade Release Note
 
+## 0.9.2 [next]
+
+* Exposed name property in JLogger 
+
 ## 0.9.1 [2024-02-24]
 
 * Created `helper.safeStringify` to address circular structure error from `JSON.strigify`

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,7 +38,7 @@ export type TLoggableEntry = Error | TLoggableParam;
  * Json Logger objact.  Do not use this class directly; always create an instance of JLogger using {@link LoggerFactory}
  */
 export class JLogger {
-    constructor(private name: string, public readonly logLevel?: LogLevel) {}
+    constructor(public readonly name: string, public readonly logLevel?: LogLevel) {}
 
     /**
      * Isolate the first error from the params and return a clean LoggableParams.  This is needed

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -484,4 +484,14 @@ describe('logger', () => {
             key2: 'LxZFU8NMUq'
         });
     });
+
+    it('Test public properties', () => {
+        const loggerName = 'test-logger';
+        const logLevel = LogLevel.DEBUG;
+        const logger = LoggerFactory.create(loggerName, logLevel);
+
+
+        expect(logger.name).is.eql(loggerName);
+        expect(logger.logLevel).is.eql(logLevel);
+    })
 });


### PR DESCRIPTION
Exposed `name` prop in `JLogger` class.  This closes #27.